### PR TITLE
MySQL as dependency & Configuration value for debug mode

### DIFF
--- a/com/github/mashlol/MySQL.java
+++ b/com/github/mashlol/MySQL.java
@@ -9,14 +9,14 @@ import java.sql.SQLException;
 public class MySQL {
 
 	private Connection con = null;
-	
+        public static boolean dbstatus = true;
+        
 	public MySQL () {
 		final String driver = "com.mysql.jdbc.Driver";
 		String connection = "jdbc:mysql://" + StockMarket.mysqlIP + ":" + StockMarket.mysqlPort + "/" + StockMarket.mysqlDB;
 		final String user = StockMarket.mysqlUser;
 		final String password = StockMarket.mysqlPW;
-		
-		
+			
 		try {
 			Class.forName(driver);
 			con = DriverManager.getConnection(connection, user, password);
@@ -37,14 +37,22 @@ public class MySQL {
 				setUpTables();
 			} catch (SQLException e1) {
 				// TODO Auto-generated catch block
-				e1.printStackTrace();
+                                System.out.println("[StockMarket] " + "Failed to create database during initialisation. Most likely due to incorrect database settings in config file.");
+                                if (StockMarket.debugMode == true) {
+                                    e1.printStackTrace();
+                                }
+                                dbstatus = false;
 			}
 			
 			//e.printStackTrace();
 		} catch (ClassNotFoundException e) {
 			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+                        System.out.println("[StockMarket] " + "SQL Drivers not installed. The server and java installation must support JDBC connections.");
+                        if (StockMarket.debugMode == true) {
+                            e.printStackTrace();
+                        }
+                        dbstatus = false;
+                }
 	}
 	
 	private void setUpTables() {
@@ -53,9 +61,12 @@ public class MySQL {
 			execute("CREATE TABLE IF NOT EXISTS players (id int NOT NULL AUTO_INCREMENT, PRIMARY KEY(id), name tinytext)");
 			execute("CREATE TABLE IF NOT EXISTS looptime (looptime int NOT NULL DEFAULT 0, PRIMARY KEY(looptime), looptime2 int NOT NULL DEFAULT 0)");	
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+                        System.out.println("[StockMarket] " + "Could not execute create table statements during initialisation.");
+                        if (StockMarket.debugMode == true) {
+                            e.printStackTrace();
+                        }
+                        dbstatus = false;
+                }
 			ResultSet result = query("SELECT * FROM looptime");
 			
 			try {
@@ -65,25 +76,40 @@ public class MySQL {
 				}
 				if (!found) {
 					try {
-						execute("INSERT INTO looptime (looptime, looptime2) VALUES(0, 0)");
+                                            execute("INSERT INTO looptime (looptime, looptime2) VALUES(0, 0)");
 					} catch (SQLException e) {
-						e.printStackTrace();
+                                            System.out.println("[StockMarket] " + "Database Error - Could not update looptime!");
+                                            if (StockMarket.debugMode == true) {
+                                                e.printStackTrace();
+                                            }
+                                            dbstatus = false;
 					}	
 				}
 			} catch (SQLException e) {
-				e.printStackTrace();
+                            System.out.println("[StockMarket] " + "General Database error. Enable debug-mode for more info!");
+                            if (StockMarket.debugMode == true) {
+                                e.printStackTrace();
+                            }
+                            dbstatus = false;
 			}
 			
 			try {
 				execute("ALTER TABLE stocks ADD COLUMN amount int");
 			} catch (SQLException e) {
-				// DO NOTHING
-			}
-			
+                            System.out.println("[StockMarket] " + "General Database error. Could not add amount column to stocks table! Enable debug-mode for more info.");
+                            if (StockMarket.debugMode == true) {
+                                e.printStackTrace();
+                            }
+                            dbstatus = false;
+                        }			
 			try {
 				execute("ALTER TABLE stocks ADD COLUMN dividend decimal(10, 2)");
 			} catch (SQLException e) {
-				// DO NOTHING
+                            System.out.println("[StockMarket] " + "General Database error. Could not add dividend column to stocks table! Enable debug-mode for more info.");
+                            if (StockMarket.debugMode == true) {
+                                e.printStackTrace();
+                            }	
+                            dbstatus = false;
 			}
 	}
 			
@@ -94,7 +120,11 @@ public class MySQL {
 		try {
 			rs = stmt.executeQuery();
 		} catch (SQLException e4) {
-			e4.printStackTrace();
+                            System.out.println("[StockMarket] " + "General Database error. Enable debug-mode for more info.");
+                            if (StockMarket.debugMode == true) {
+                                e4.printStackTrace();
+                            }	
+                            dbstatus = false;
 		}
 		
 		return rs;
@@ -107,7 +137,11 @@ public class MySQL {
 			PreparedStatement stmt = prepareStatement(string);
 			rs = stmt.executeQuery();
 		} catch (SQLException e4) {
-			e4.printStackTrace();
+                            System.out.println("[StockMarket] " + "General Database error. Enable debug-mode for more info.");
+                            if (StockMarket.debugMode == true) {
+                                e4.printStackTrace();
+                            }
+                            dbstatus = false;
 		}
 		
 		return rs;
@@ -118,14 +152,17 @@ public class MySQL {
 		try {
 			stmt.execute();
 		} catch (SQLException e4) {
-			e4.printStackTrace();
-		}
+                            System.out.println("[StockMarket] " + "General Database error. Enable debug-mode for more info.");
+                            if (StockMarket.debugMode == true) {
+                                e4.printStackTrace();
+                            }	
+                            dbstatus = false;
+                }
 	}
 	
 	public void execute (String s) throws SQLException {
 		
 		PreparedStatement stmt = prepareStatement(s);
-		
 		stmt.execute();
 	}
 	
@@ -133,8 +170,11 @@ public class MySQL {
 		try {
 			con.close();
 		} catch (SQLException e) {
-			System.out.println("A bad call to mysql.close() occurred");	
-			e.printStackTrace();
+                            System.out.println("[StockMarket] " + "General Database error. Could not close SQL connection after use! Enable debug-mode for more info.");
+                            if (StockMarket.debugMode == true) {
+                                e.printStackTrace();
+                            }	
+                            dbstatus = false;
 		}
 	}
 	
@@ -143,8 +183,11 @@ public class MySQL {
 		try {
 			stmt = con.prepareStatement(s);
 		} catch (SQLException e) {
-			System.out.println("An unexpected error occurred while generating a PreparedStatement"); 
-			e.printStackTrace();
+                            System.out.println("[StockMarket] " + "General Database error. Could not convert " + s + " to a prepared database statement! Enable debug-mode for more info.");
+                            if (StockMarket.debugMode == true) {
+                                    e.printStackTrace();
+                            }
+                            dbstatus = false;
 		}
 
 		return stmt;

--- a/config.yml
+++ b/config.yml
@@ -10,6 +10,8 @@ dividend-frequency: 1440
 pay-offline-players: true
 # Broadcast events?
 broadcast-events: true
+# Debug mode setting (Shows stack-traces if true)
+debug-mode: false
 # Broadcast dividend payouts?
 broadcast-payouts: true
 mysql:

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,91 @@
+# How many stocks is the player allowed in total?
+max-total-stocks-per-player: 250 
+# How many stocks is the player allowed of each stock?
+max-total-stocks-per-player-per-stock: 50
+# How often in minutes should random events occur?
+random-event-frequency: 60
+# How often in minutes should dividends be paid out?
+dividend-frequency: 1440
+# Should offline players be paid during dividend payouts?
+pay-offline-players: true
+# Broadcast events?
+broadcast-events: true
+# Broadcast dividend payouts?
+broadcast-payouts: true
+mysql:
+    ip: localhost
+    port: 3306
+    username: root
+    password: ""
+    database: sm
+events:
+    0:
+       message: "The CEO of %s has died of a heart attack.  The replacement is looking to be a poor one."
+       effect: 40
+       up: false
+       frequency: 50
+    1:
+       message: "The CEO of %s has died of a heart attack.  The replacement looks like he is even better than his successor!"
+       effect: 40
+       up: true
+       frequency: 50
+    2:
+       message: "%s has announced a new product to be released!  Speculation is high!"
+       effect: 8
+       up: true
+       frequency: 250
+    3:
+       message: "%s has announced a new product to be released!  Speculation is high!"
+       effect: 8
+       up: false
+       frequency: 250
+    4:
+       message: "%s's announced product was a huge success, customers are extremely satisfied!"
+       effect: 45
+       up: true
+       frequency: 250
+    5:
+       message: "%s's announced product was poorly made, causing poor customer satisfaction!"
+       effect: 45
+       up: false
+       frequency: 250
+    6:
+       message: "%s had a bad quarter."
+       effect: 30
+       up: false
+       frequency: 100
+    7:
+       message: "%s had a fantastic quarter."
+       effect: 30
+       up: true
+       frequency: 100
+    8:
+       message: "Everyone is speculating that %s is soon to come out with an extremely amazing product!"
+       effect: 65
+       up: true
+       frequency: 5
+    9:
+       message: "%s is on the brink of bankruptcy."
+       effect: 65
+       up: false
+       frequency: 5
+    10:
+       message: "%s just invented the next best thing since sliced bread!"
+       effect: 400
+       up: true
+       frequency: 1
+    11:
+       message: "%s just went bankrupt."
+       effect: 400
+       up: false
+       frequency: 1
+    12:
+       message: "%s just announced that they are replacing their current CEO, who has a bad reputation."
+       effect: 25
+       up: true
+       frequency: 25
+    13:
+       message: "%s just announced that they are replacing their current CEO, who everyone loves."
+       effect: 25
+       up: false
+       frequency: 25

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,0 +1,8 @@
+name: StockMarket
+main: com.github.mashlol.StockMarket
+version: .06
+depend: [Vault]
+commands:
+   sm:
+      description: Core StockMarket command.
+      usage: /sm

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: StockMarket
 main: com.github.mashlol.StockMarket
-version: .06
+version: .08
 depend: [Vault]
 commands:
    sm:


### PR DESCRIPTION
Hi Mashlol,

+ Modified the MySQL class to support returning a true/false status value and added it as a dependency on startup. If DB Connect, Create etc fails on load, it will now print an English message to remove the confusion of less knowing users (See bukkitdev comments).

+ Added debug-mode configuration flag, to allow us to re-enable stack traces for SQL as required (will do this for other classes if you like)

+ Added the default config.yml and plugin.yml to the repo I have as it needs to be included in the jar for it to function.

+ Added a StockMarket.disablePlugin() function which is now called whenever the plugin tries to 
terminate.

Tested on:
Bukkit 1.8.8 + Vault 1.5.6 + CraftConomy 3.3
Bukkit 1.7.10 + Vault 1.4.1 + CraftConomy 3.2.1
KCauldron 1.7.10 + Vault 1.4.1 + CraftConomy 3.2.1

If you have any concerns let me know :) 
